### PR TITLE
Bugfix: Gate Deploying Misc Manifests Behind When Conditional

### DIFF
--- a/ansible/playbooks/roles/manifests/tasks/deploy_manifests.yaml
+++ b/ansible/playbooks/roles/manifests/tasks/deploy_manifests.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Check if Local Manifests Directory Exists
   stat:
-    path: ../../../../../manifests/
+    path: "{{ playbook_dir }}/../../manifests"
   register: manifests_dir
   delegate_to: localhost
 


### PR DESCRIPTION
Check if a local manifests directory exists on the Ansible control node before attempting to copy manifests to the leader.

If the manifests directory doesn't exist when this is run, you'll end up with an error that looks like this:

```
TASK [manifests : Push Manifests to Leader] ******************************************************************************
task path: /workspace/ansible/playbooks/roles/manifests/tasks/deploy_manifests.yaml:9
<i-09cfeeaa345206185> ESTABLISH SSM CONNECTION TO: i-09cfeeaa345206185
<i-09cfeeaa345206185> ESTABLISH SSM CONNECTION TO: i-09cfeeaa345206185
<i-09cfeeaa345206185> EXEC: echo ~ssm-user
<i-09cfeeaa345206185> EXEC: ( umask 77 && mkdir -p "` echo /home/ssm-user/.ansible/tmp `"&& mkdir "` echo /home/ssm-user/.ansible/tmp/ansible-tmp-1755232036.000288-9070-224436980093934 `" && echo ansible-tmp-1755232036.000288-9070-224436980093934="` echo /home/ssm-user/.ansible/tmp/ansible-tmp-1755232036.000288-9070-224436980093934 `" )
<i-09cfeeaa345206185> EXEC: rm -f -r /home/ssm-user/.ansible/tmp/ansible-tmp-1755232036.000288-9070-224436980093934/ > /dev/null 2>&1
The full traceback is:
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/ansible/plugins/action/copy.py", line 474, in run
    source = self._find_needle('files', source)
  File "/usr/local/lib/python3.13/site-packages/ansible/plugins/action/__init__.py", line 1433, in _find_needle
    return self._loader.path_dwim_relative_stack(path_stack, dirname, needle)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/ansible/parsing/dataloader.py", line 351, in path_dwim_relative_stack
    raise AnsibleFileNotFound(file_name=source, paths=[to_native(p) for p in search])
ansible.errors.AnsibleFileNotFound: Could not find or access '../../../../../manifests/'
Searched in:
        /workspace/ansible/playbooks/roles/manifests/files/../../../../../manifests/
        /workspace/ansible/playbooks/roles/manifests/../../../../../manifests/
        /workspace/ansible/playbooks/roles/manifests/tasks/files/../../../../../manifests/
        /workspace/ansible/playbooks/roles/manifests/tasks/../../../../../manifests/
        /workspace/ansible/playbooks/files/../../../../../manifests/
        /workspace/ansible/playbooks/../../../../../manifests/ on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [aws-controller]: FAILED! => {
    "changed": false,
    "invocation": {
        "dest": "/root/misc_manifests",
        "mode": "0640",
        "module_args": {
            "dest": "/root/misc_manifests",
            "mode": "0640",
            "src": "../../../../../manifests/"
        },
        "src": "../../../../../manifests/"
    },
    "msg": "Could not find or access '../../../../../manifests/'\nSearched in:\n\t/workspace/ansible/playbooks/roles/manifests/files/../../../../../manifests/\n\t/workspace/ansible/playbooks/roles/manifests/../../../../../manifests/\n\t/workspace/ansible/playbooks/roles/manifests/tasks/files/../../../../../manifests/\n\t/workspace/ansible/playbooks/roles/manifests/tasks/../../../../../manifests/\n\t/workspace/ansible/playbooks/files/../../../../../manifests/\n\t/workspace/ansible/playbooks/../../../../../manifests/ on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
```