### PR TITLE
Support EC2 Dynamic Inventory + SSM Connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ vars/*
 /manifests/*
 
 # Ignore aws inventories
-/ansible/inventory/aws.yaml
+/ansible/inventory/aws_ec2.yaml
+/ansible/inventory/group_vars/aws_ec2

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ finished with the resources so that you don't continue to get charged.
 
 * [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 * [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+* Install Ansible collections
+
+  ```bash
+  ansible-galaxy collection install -r ansible/collections.yml
+  ```
+
+* For aws: Ensure that boto is installed for the AWS ansible collections to
+work correctly:
+
+```sh
+pip install boto3
+```
+
+* For aws: Ensure that the AWS Session Manager [plugin is installed](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 * For libvirt: Ensure that `wget` and `qemu-img` commands are installed and
   available on the host running terraform
 * For libvirt: Add the following to your `/etc/hosts` file so that the hosts are
@@ -89,14 +103,14 @@ above.
 
 * For libvirt: From this project repo run:
 
-```
+```sh
 ansible-playbook -i ansible/inventory/hosts.yaml ansible/playbooks/kube-router-containerd.yaml`
 ```
 
 * For AWS: From this project repo run:
 
-```
-ansible-playbook -i ansible/inventory/aws.yaml ansible/playbooks/kube-router-crio.yaml
+```sh
+ansible-playbook -i ansible/inventory/aws_ec2.yaml ansible/playbooks/kube-router-crio.yaml
 ```
 
 ## Tearing Down Your Cluster
@@ -144,6 +158,8 @@ This is the image that you wish to use as your base Ubuntu image for running kub
 
 * **aws_key_name** - NO_DEFAULT_SET - The SSH key name in AWS that you want to
   use for logging into the instances
+* enable_ssm - true - If true, the Ansible inventory file will be generated
+  to connect to AWS instances using SSM. If false, then SSH will be used.
 * **region** - `us-west-2` - The AWS region that you are deploying into
 * **name** - `kube-router` - The default name to use for AWS tags and instances
 * **tags** - `owner = "kube-router"` - Any additional tags that you want to set
@@ -166,7 +182,6 @@ This is the image that you wish to use as your base Ubuntu image for running kub
   `ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-*-amd64-minimal-*` -
   Allows you to set a filter for the AMI that you want to base your instances
   off of
-
 
 ### Ansible Variables
 

--- a/ansible/collections.yml
+++ b/ansible/collections.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: amazon.aws
+    version: "9.5.0"
+  - name: community.aws
+    version: "9.3.0"
+  - name: ansible.posix
+    version: "1.6.2"
+  - name: community.general
+    version: "10.7.3"

--- a/ansible/playbooks/kube-router-containerd.yaml
+++ b/ansible/playbooks/kube-router-containerd.yaml
@@ -58,10 +58,16 @@
     - setup
     - checks
   tasks:
-    - name: Check for Hosts to be up
+    - name: Check for Hosts to be up via SSM
+      import_role:
+        name: common
+        tasks_from: wait_for_ssm
+      when: '"aws_ssm" in ansible_connection'
+    - name: Check for Hosts to be up via SSH
       import_role:
         name: common
         tasks_from: wait_for_ssh
+      when: ansible_connection == "ssh"
 
 - name: Ensure IPv6 NAT Config
   hosts: localhost

--- a/ansible/playbooks/kube-router-crio.yaml
+++ b/ansible/playbooks/kube-router-crio.yaml
@@ -58,10 +58,16 @@
     - setup
     - checks
   tasks:
+    - name: Check for Hosts to be up via SSM
+      import_role:
+        name: common
+        tasks_from: wait_for_ssm
+      when: '"aws_ssm" in ansible_connection'
     - name: Check for Hosts to be up
       import_role:
         name: common
         tasks_from: wait_for_ssh
+      when: ansible_connection == "ssh"
 
 - name: Ensure IPv6 NAT Config
   hosts: localhost

--- a/ansible/playbooks/roles/common/tasks/wait_for_ssm.yaml
+++ b/ansible/playbooks/roles/common/tasks/wait_for_ssm.yaml
@@ -1,0 +1,3 @@
+---
+- name: Wait for instance to be reachable via SSM
+  ansible.builtin.wait_for_connection:

--- a/ansible/playbooks/roles/config/tasks/localize_config.yaml
+++ b/ansible/playbooks/roles/config/tasks/localize_config.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Find UID
   become: false
   command: id -u
@@ -30,7 +29,7 @@
   file:
     path: "{{ home.stdout }}/.kube"
     state: directory
-    mode: '0750'
+    mode: "0750"
     owner: "{{ user_id.stdout }}"
     group: "{{ group_id.stdout }}"
 
@@ -51,7 +50,7 @@
     # Because we used a loop command (even over just one host) we have to parse results to get to stdout
     src: "{{ home.stdout }}/.kube/config"
     dest: "{{ home.stdout }}/.kube/config.bak"
-    mode: '0600'
+    mode: "0600"
     owner: "{{ user_id.stdout }}"
     group: "{{ group_id.stdout }}"
   when: local_config_path.stat.exists
@@ -61,7 +60,7 @@
     # Because we used a loop command (even over just one host) we have to parse results to get to stdout
     content: "{{ kube_config['results'][0]['content'] | b64decode }}"
     dest: "{{ home.stdout }}/.kube/config"
-    mode: '0600'
+    mode: "0600"
     owner: "{{ user_id.stdout }}"
     group: "{{ group_id.stdout }}"
 
@@ -69,5 +68,5 @@
   replace:
     path: "{{ home.stdout }}/.kube/config"
     regexp: '{{ hostvars["aws-controller"].ansible_default_ipv4.address }}'
-    replace: '{{ hostvars["aws-controller"].ansible_host }}'
+    replace: '{{ hostvars["aws-controller"].ec2_public_ip if hostvars["aws-controller"].get("ec2_public_ip", "") != "" else hostvars["aws-controller"].ansible_host }}'
   when: hostvars["aws-controller"] is defined

--- a/ansible/playbooks/roles/kubernetes/templates/kubeadm-config.yaml.j2
+++ b/ansible/playbooks/roles/kubernetes/templates/kubeadm-config.yaml.j2
@@ -9,6 +9,9 @@ apiServer:
     - "{{ ansible_default_ipv4.address }}"
     - "{{ ansible_default_ipv6.address }}"
     - "{{ ansible_host }}"
+{% if ec2_public_ip is defined and ec2_public_ip %}
+    - "{{ ec2_public_ip }}"
+{% endif %}
 #  extraArgs:
 #    feature-gates: NetworkPolicyEndPort=true
 networking:

--- a/terraform_aws/ansible.tf
+++ b/terraform_aws/ansible.tf
@@ -1,17 +1,29 @@
 resource "local_file" "ansible_inventory" {
-  depends_on = [
-    aws_instance.kube-controller,
-    aws_instance.kube-worker,
-    aws_instance.bgp-receiver
-  ]
   content = templatefile(
     "${path.module}/resources/inventory.tmpl",
     {
-      controller   = aws_instance.kube-controller.public_ip
-      worker       = aws_instance.kube-worker.public_ip
-      bgp          = aws_instance.bgp-receiver.public_ip
-      default_user = var.ami_default_user
+      region                  = var.region
+      ansible_ssm_bucket_name = var.enable_ssm ? aws_s3_bucket.ansible_ssm_bucket[0].bucket : ""
+      enable_ssm              = var.enable_ssm
+      controller              = aws_instance.kube-controller.public_ip
+      worker                  = aws_instance.kube-worker.public_ip
+      bgp                     = aws_instance.bgp-receiver.public_ip
+      default_user            = var.ami_default_user
     }
   )
-  filename = "../ansible/inventory/aws.yaml"
+  filename = "../ansible/inventory/aws_ec2.yaml"
+}
+
+resource "local_file" "ansible_group_vars" {
+  count    = var.enable_ssm ? 1 : 0
+  content  = <<-EOF
+ansible_connection: "community.aws.aws_ssm"
+ansible_user: ssm-user
+ansible_become: true
+ansible_become_method: sudo
+ansible_become_user: root
+ansible_aws_ssm_bucket_name: ${aws_s3_bucket.ansible_ssm_bucket[0].bucket}
+ansible_python_interpreter: /usr/bin/python3
+EOF
+  filename = "../ansible/inventory/group_vars/aws_ec2"
 }

--- a/terraform_aws/configs/cloud_init.cfg
+++ b/terraform_aws/configs/cloud_init.cfg
@@ -25,10 +25,19 @@ packages:
   - jq
   - file
   - tcpdump
-  %{ if ami_type == "ubuntu" }
+%{ if ami_type == "ubuntu" ~}
   - apt-transport-https
   - tig
-  %{ endif }
+%{ endif ~}
+%{ if enable_ssm ~}
+  - amazon-ssm-agent
+runcmd:
+  - [ systemctl, enable, amazon-ssm-agent ]
+  - [ systemctl, restart, amazon-ssm-agent ]
+users:
+  - name: ssm-user
+    sudo: ALL=(ALL) NOPASSWD:ALL
+%{ endif ~}
 write_files:
   - path: /etc/sysctl.d/99-k8s.conf
     content: |

--- a/terraform_aws/main.tf
+++ b/terraform_aws/main.tf
@@ -27,6 +27,7 @@ locals {
           Name = "controller-root-block"
         }
       }
+      ssm_enabled = var.enable_ssm
       tags = {
         Name = "aws-controller"
         type = "controller"
@@ -45,6 +46,7 @@ locals {
           Name = "worker-root-block"
         }
       }
+      ssm_enabled = var.enable_ssm
       tags = {
         Name = "aws-worker"
         type = "worker"
@@ -63,6 +65,7 @@ locals {
           Name = "bgp-root-block"
         }
       }
+      ssm_enabled = var.enable_ssm
       tags = {
         Name = "aws-bgp"
         type = "bgp"
@@ -190,7 +193,7 @@ resource "aws_instance" "kube-controller" {
   vpc_security_group_ids      = [aws_security_group.web-sg.id]
   ipv6_address_count          = 1
   associate_public_ip_address = true
-  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type })
+  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type, enable_ssm = var.enable_ssm })
   source_dest_check           = false
 
   root_block_device {
@@ -222,7 +225,7 @@ resource "aws_instance" "kube-worker" {
   vpc_security_group_ids      = [aws_security_group.web-sg.id]
   ipv6_address_count          = 1
   associate_public_ip_address = true
-  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type })
+  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type, enable_ssm = var.enable_ssm })
   source_dest_check           = false
 
   root_block_device {
@@ -254,7 +257,7 @@ resource "aws_instance" "bgp-receiver" {
   vpc_security_group_ids      = [aws_security_group.web-sg.id]
   ipv6_address_count          = 1
   associate_public_ip_address = true
-  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type })
+  user_data                   = templatefile("${path.module}/configs/cloud_init.cfg", { ami_type = var.ami_type, enable_ssm = var.enable_ssm })
   source_dest_check           = false
 
   root_block_device {

--- a/terraform_aws/resources/inventory.tmpl
+++ b/terraform_aws/resources/inventory.tmpl
@@ -1,6 +1,41 @@
-aws-controller ansible_host=${ controller } ansible_user=${ default_user } ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
-aws-worker ansible_host=${ worker } ansible_user=${ default_user } ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
-aws-bgp ansible_host=${ bgp } ansible_user=${ default_user } ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
+%{ if enable_ssm ~}
+plugin: amazon.aws.aws_ec2
+
+regions:
+  - ${region}
+
+compose:
+  ansible_host: instance_id
+  ansible_aws_ssm_instance_id: instance_id
+  ansible_aws_ssm_region: ${region}
+  ansible_aws_ssm_bucket_name: ${ansible_ssm_bucket_name}
+  ansible_python_interpreter: /usr/bin/python3
+  ec2_public_ip: public_ip_address | default('', true)
+
+filters:
+  tag:type:
+    - controller
+    - worker
+    - bgp
+  instance-state-name: running
+
+hostnames:
+  - tag:Name
+
+keyed_groups:
+  - key: tags.type
+    separator: ""
+
+groups:
+  container_runners: "tags.type == 'controller' or tags.type == 'worker'"
+  controllers: "tags.type == 'controller'" 
+  leader: "tags.type == 'controller'"
+  workers: "tags.type == 'worker'"
+  bgp_routers: "tags.type == 'bgp'"
+%{ else ~}
+aws-controller ansible_host=${controller} ansible_user=${default_user} ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
+aws-worker ansible_host=${worker} ansible_user=${default_user} ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
+aws-bgp ansible_host=${bgp} ansible_user=${default_user} ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3
 
 [container_runners]
 aws-controller
@@ -17,3 +52,4 @@ aws-worker
 
 [bgp_routers]
 aws-bgp
+%{ endif ~}

--- a/terraform_aws/sshconfig.tf
+++ b/terraform_aws/sshconfig.tf
@@ -1,9 +1,5 @@
 resource "local_file" "ssh_config" {
-  depends_on = [
-    aws_instance.kube-controller,
-    aws_instance.kube-worker,
-    aws_instance.bgp-receiver
-  ]
+  count = var.enable_ssm ? 0 : 1
   content = templatefile(
     "${path.module}/resources/ssh_config.tmpl",
     {

--- a/terraform_aws/ssm.tf
+++ b/terraform_aws/ssm.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_role_policy_attachment" "ssm-control-plane-policy-attachment" {
+  count      = var.enable_ssm ? 1 : 0
+  role       = aws_iam_role.control-plane-role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "ssm-worker-policy-attachment" {
+  count      = var.enable_ssm ? 1 : 0
+  role       = aws_iam_role.worker-role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# S3 bucket required for the Ansible aws_ssm connection plugin to work: 
+# https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html#requirements
+resource "aws_s3_bucket" "ansible_ssm_bucket" {
+  count  = var.enable_ssm ? 1 : 0
+  bucket = var.ansible_ssm_bucket_name
+
+  force_destroy = true
+}

--- a/terraform_aws/variables.tf
+++ b/terraform_aws/variables.tf
@@ -4,6 +4,11 @@ variable "aws_key_name" {
   default = ""
 }
 
+variable "enable_ssm" {
+  type    = bool
+  default = true
+}
+
 variable "region" {
   type    = string
   default = "us-west-2"
@@ -90,4 +95,9 @@ variable "ami_default_user" {
 variable "ami_type" {
   type    = string
   default = "ubuntu"
+}
+
+variable "ansible_ssm_bucket_name" {
+  type    = string
+  default = "kube-router-aws-ssm-ansible"
 }


### PR DESCRIPTION
Adds support for the Ansible [EC2 dynamic inventory plugin](https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/aws_ec2_guide.html) and using the [AWS SSM connection plugin](https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html). 

Allows for toggling between using SSM or SSH based off of the "enable_ssm" variable flag.

Couple of notes:
* I had to update the inventory file from aws.yaml to aws_ec2.yaml because the dynamic inventory plugin requires that the file must end with "aws_ec2.{yml|yaml}". 
* I removed the `depends_on` blocks on the local_files since they're not necessary with the implicit dependencies on the hosts from the attribute references. With them, if I did subsequent applies after changing the template, I got this fun "Error: Provider produced inconsistent final plan... This is a bug in the provider, which should be reported in the provider's own issue tracker." 