### PR TITLE
Make Docker Repo Completely Configurable

### DIFF
--- a/ansible/playbooks/roles/kube_router/templates/kube-router.yaml.j2
+++ b/ansible/playbooks/roles/kube_router/templates/kube-router.yaml.j2
@@ -50,9 +50,9 @@ spec:
       containers:
       - name: kube-router
         {%- if kube_router_version is defined %}
-        image: docker.io/{{ kube_router_docker_repo }}:{{ kube_router_version }}
+        image: {{ kube_router_docker_repo }}:{{ kube_router_version }}
         {%- else %}
-        image: docker.io/{{ kube_router_docker_repo }}
+        image: {{ kube_router_docker_repo }}
         {%- endif %}
         imagePullPolicy: Always
         args:

--- a/ansible/playbooks/roles/kube_router/vars/main.yaml
+++ b/ansible/playbooks/roles/kube_router/vars/main.yaml
@@ -3,9 +3,6 @@
 # manifest: https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml
 
 # For having all features of kube-router enabled
-manifest:
-  "https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter-all-features.yaml"
-kube_router_docker_repo:
-  cloudnativelabs/kube-router
-kube_router_version:
-  latest
+manifest: "https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter-all-features.yaml"
+kube_router_docker_repo: docker.io/cloudnativelabs/kube-router
+kube_router_version: latest


### PR DESCRIPTION
Removes docker.io registry from the image name to make the kube_router_docker_repo variable completely configurable. 

Made this change because I'm trying to test a kube-router image that I pushed to ghcr.io