### PR TITLE
Randomize AWS bucket name

### DIFF
--- a/terraform_aws/ssm.tf
+++ b/terraform_aws/ssm.tf
@@ -10,11 +10,22 @@ resource "aws_iam_role_policy_attachment" "ssm-worker-policy-attachment" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "random_string" "ansible_ssm_bucket_suffix" {
+  count   = var.enable_ssm ? 1 : 0
+  length  = 6
+  special = false
+  upper   = false
+
+  keepers = {
+    bucket_name = var.ansible_ssm_bucket_name
+  }
+}
+
 # S3 bucket required for the Ansible aws_ssm connection plugin to work: 
 # https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html#requirements
 resource "aws_s3_bucket" "ansible_ssm_bucket" {
   count  = var.enable_ssm ? 1 : 0
-  bucket = var.ansible_ssm_bucket_name
+  bucket = "${var.ansible_ssm_bucket_name}-${random_string.ansible_ssm_bucket_suffix[0].result}"
 
   force_destroy = true
 }

--- a/terraform_aws/versions.tf
+++ b/terraform_aws/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source = "hashicorp/local"
       version = "2.2.3"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
 
   required_version = ">= 1.2.0"


### PR DESCRIPTION
Bucket names are global in AWS. Having the bucket name be static means that if two people are using this Terraform at the same time, then only one person will be able to use the bucket name. 

I'm adding the suffix onto the variable that's passed in for convenience. Happy to make the change to make it so that this suffix only gets applied to the default bucket name though. 