### PR TITLE
fix(cloud_init.cfg): increase inotify instances and watches

### DIFF
--- a/terraform_aws/configs/cloud_init.cfg
+++ b/terraform_aws/configs/cloud_init.cfg
@@ -48,5 +48,7 @@ write_files:
       net.ipv4.conf.default.forwarding = 1
       net.ipv6.conf.default.forwarding = 1
       net.ipv6.conf.all.forwarding = 1
+      fs.inotify.max_user_instances = 65536
+      fs.inotify.max_user_watches = 262144
     owner: root:root
     permissions: '0644'

--- a/terraform_libvirt/configs/cloud_init.cfg
+++ b/terraform_libvirt/configs/cloud_init.cfg
@@ -45,5 +45,7 @@ write_files:
       net.bridge.bridge-nf-call-iptables = 1
       net.ipv4.ip_forward = 1
       net.ipv6.conf.default.forwarding = 1
+      fs.inotify.max_user_instances = 65536
+      fs.inotify.max_user_watches = 262144
     owner: root:root
     permissions: '0644'


### PR DESCRIPTION
@catherinetcai 

Found this when trying to start up a bunch of pods, ran into an issue where SSM wouldn't let me login any longer due to open file limits, which actually had to do with Ubuntu's crazy low default settings for inotify instances and watches.