### PR TITLE
Have SSM Connect as the Default User instead of ssm-user

### DIFF
--- a/terraform_aws/ansible.tf
+++ b/terraform_aws/ansible.tf
@@ -2,13 +2,12 @@ resource "local_file" "ansible_inventory" {
   content = templatefile(
     "${path.module}/resources/inventory.tmpl",
     {
-      region                  = var.region
-      ansible_ssm_bucket_name = var.enable_ssm ? aws_s3_bucket.ansible_ssm_bucket[0].bucket : ""
-      enable_ssm              = var.enable_ssm
-      controller              = aws_instance.kube-controller.public_ip
-      worker                  = aws_instance.kube-worker.public_ip
-      bgp                     = aws_instance.bgp-receiver.public_ip
-      default_user            = var.ami_default_user
+      bgp          = aws_instance.bgp-receiver.public_ip
+      controller   = aws_instance.kube-controller.public_ip
+      default_user = var.ami_default_user
+      enable_ssm   = var.enable_ssm
+      region       = var.region
+      worker       = aws_instance.kube-worker.public_ip
     }
   )
   filename = "../ansible/inventory/aws_ec2.yaml"
@@ -17,13 +16,14 @@ resource "local_file" "ansible_inventory" {
 resource "local_file" "ansible_group_vars" {
   count    = var.enable_ssm ? 1 : 0
   content  = <<-EOF
-ansible_connection: "community.aws.aws_ssm"
-ansible_user: ssm-user
-ansible_become: true
+ansible_aws_ssm_bucket_name: ${aws_s3_bucket.ansible_ssm_bucket[0].bucket}
+ansible_aws_ssm_document: ${aws_ssm_document.ssm_default_user[0].name}
+ansible_aws_ssm_region: ${var.region}
 ansible_become_method: sudo
 ansible_become_user: root
-ansible_aws_ssm_bucket_name: ${aws_s3_bucket.ansible_ssm_bucket[0].bucket}
+ansible_connection: "community.aws.aws_ssm"
 ansible_python_interpreter: /usr/bin/python3
+ansible_user: ${var.ami_default_user}
 EOF
   filename = "../ansible/inventory/group_vars/aws_ec2"
 }

--- a/terraform_aws/resources/inventory.tmpl
+++ b/terraform_aws/resources/inventory.tmpl
@@ -7,9 +7,6 @@ regions:
 compose:
   ansible_host: instance_id
   ansible_aws_ssm_instance_id: instance_id
-  ansible_aws_ssm_region: ${region}
-  ansible_aws_ssm_bucket_name: ${ansible_ssm_bucket_name}
-  ansible_python_interpreter: /usr/bin/python3
   ec2_public_ip: public_ip_address | default('', true)
 
 filters:

--- a/terraform_aws/ssm.tf
+++ b/terraform_aws/ssm.tf
@@ -29,3 +29,26 @@ resource "aws_s3_bucket" "ansible_ssm_bucket" {
 
   force_destroy = true
 }
+
+# SSM document to set default user for SSM sessions
+resource "aws_ssm_document" "ssm_default_user" {
+  count           = var.enable_ssm ? 1 : 0
+  name            = "ConnectAsDefaultUser"
+  document_type   = "Session"
+  document_format = "JSON"
+
+  content = jsonencode({
+    schemaVersion = "1.0"
+    description   = "Document to configure default user for Session Manager"
+    sessionType   = "Standard_Stream"
+    inputs = {
+      runAsEnabled     = true
+      runAsDefaultUser = var.ami_default_user
+    }
+  })
+
+  tags = merge(
+    { "Name" = "ssm-default-user" },
+    var.tags
+  )
+}


### PR DESCRIPTION
Fixes the issues previously where the kubeconfig was getting copied into root's $HOME.

```
ubuntu@aws-controller:/var/snap/amazon-ssm-agent/11797$ ls -al ~/.kube/
total 20
drwxr-x--- 3 ubuntu ubuntu 4096 Sep  5 03:53 .
drwxr-x--- 7 ubuntu ubuntu 4096 Sep  5 03:57 ..
drwxr-x--- 4 ubuntu ubuntu 4096 Sep  5 03:53 cache
-rw------- 1 ubuntu ubuntu 5655 Sep  5 03:52 config
```