### PR TITLE
feat(frr): Update FRR settings to enable and support minimum bfd configs

### DIFF
--- a/ansible/playbooks/roles/bgp_router/tasks/deploy_route_server.yaml
+++ b/ansible/playbooks/roles/bgp_router/tasks/deploy_route_server.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure syslog User Exists
   user:
     name: syslog
@@ -14,8 +13,15 @@
 - name: Enable BGP Daemon in FRR
   lineinfile:
     path: /etc/frr/daemons
-    regexp: '^bgpd'
+    regexp: "^bgpd"
     line: bgpd=yes
+
+- name: Enable BFD Daemon in FRR
+  lineinfile:
+    path: /etc/frr/daemons
+    regexp: "^bfdd"
+    line: bfdd=yes
+  when: enable_bfd | bool
 
 - name: Template FRR Configuration File
   vars:

--- a/ansible/playbooks/roles/bgp_router/templates/frr.conf.j2
+++ b/ansible/playbooks/roles/bgp_router/templates/frr.conf.j2
@@ -14,6 +14,22 @@ log syslog informational
 !
 # Puts all configuration into this single frr.conf file rather than having a separate config per daemon
 service integrated-vtysh-config
+{% if enable_bfd | bool %}
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Basic BFD config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+bfd
+  # Add peers
+{% for peer in bgp_peers %}
+  peer {{ hostvars[peer].ansible_facts['default_ipv4'].address }}
+    detect-multiplier 3
+    transmit-interval 100
+    receive-interval 100
+    no shutdown
+  !
+{% endfor %}
+!
+{% endif %}
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Basic BGP config to setup neighbors and peer groups
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -39,6 +55,9 @@ router bgp {{ bgp_asn }}
   # Add peers
 {% for peer in bgp_peers %}
   {{ "neighbor " + hostvars[peer].ansible_facts['default_ipv4'].address + " peer-group kubepeers" }}
+{% if enable_bfd | bool %}
+  {{ "neighbor " + hostvars[peer].ansible_facts['default_ipv4'].address + " bfd" }}
+{% endif %}
 {% endfor %}
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Configure IPv4 family

--- a/ansible/playbooks/roles/bgp_router/vars/main.yaml
+++ b/ansible/playbooks/roles/bgp_router/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+enable_bfd: false

--- a/ansible/playbooks/roles/kube_router/templates/kube-router.yaml.j2
+++ b/ansible/playbooks/roles/kube_router/templates/kube-router.yaml.j2
@@ -47,6 +47,10 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
       serviceAccount: kube-router
+      {%- if kube_router_image_pull_secret %}
+      imagePullSecrets:
+        - name: {{ kube_router_image_pull_secret }}
+      {%- endif %}
       containers:
       - name: kube-router
         {%- if kube_router_version is defined %}
@@ -84,6 +88,9 @@ spec:
         - --loadbalancer-ip-range={{ loadbalancer_ip_range.ipv6 }}
         {%- endif %}
         - --loadbalancer-ip-range={{ loadbalancer_ip_range.ipv4 }}
+        {%- endif %}
+        {%- if enable_bfd | bool %}
+        - --enable-bfd
         {%- endif %}
         - --service-external-ip-range={{ external_ip_range.ipv4 }}
         - --advertise-external-ip=true


### PR DESCRIPTION
Added BFD settings to the FRR config to be able to test https://github.com/cloudnativelabs/kube-router/pull/2118.

I added `kube_router_image_pull_secret` because I end up pushing kube-router images on my branches into my fork's container registry, which needs a PAT. I'm happy to nix this though. 